### PR TITLE
Bower.json file shouldn't list both normal & minificated version of the main file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,10 +5,7 @@
     "Lionel <elrumordelaluz@hotmail.com>"
   ],
   "description": "Some CSS classes to move your DOM!",
-  "main": [
-    "dist/csshake.css",
-    "dist/csshake.min.css"
-    ],
+  "main": "dist/csshake.css",
   "keywords": [
     "csshake",
     "css",


### PR DESCRIPTION
The main property of the bower.json file shouldn't list both the normal and the minificated version of the main file. It should list only the normal version.
Like most popular library out there like angular, lodash, jquery.
This way it's easier to work with tools like Wiredep. For exemple wiredep would list all main file, here csshake.css & csshake.min.css which result in duplicate.